### PR TITLE
Add defines to subsytem configs so C++ code can decide on main vs. WinMain

### DIFF
--- a/win/BUILD.gn
+++ b/win/BUILD.gn
@@ -51,10 +51,12 @@ toolchain("msvc") {
 
 config("windows") {
   ldflags = [ "/SUBSYSTEM:WINDOWS" ]
+  defines = [ "WIN32_SUBSYSTEM_WINDOWS" ]
 }
 
 config("console") {
   ldflags = [ "/SUBSYSTEM:CONSOLE" ]
+  defines = [ "WIN32_SUBSYSTEM_CONSOLE" ]
 }
 
 config("cpp_exceptions") {


### PR DESCRIPTION
Prep for no-console optimized build.  When using the Windows (i.e. no-console) subsystem, the C++ code has to expose wWinMain or WinMain instead of main or wmain, so add some C++ preprocessor defs so it can make that determination.